### PR TITLE
Make fix command usable from MM minion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ target/
 # debian
 debian/files
 debian/eblob-kit*
+
+# pytest temporary files
+.pytest_cache/

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Priority: optional
 Build-Depends: python-setuptools (>= 0.6b3),
                python-all (>= 2.6.6-3),
                debhelper (>= 7.4.3),
-               python-click (>= 5.1)
+               python-click (>= 5.1),
+               python-certifi
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 
@@ -15,4 +16,3 @@ Depends: ${misc:Depends},
          ${python:Depends},
          python-click (>= 5.1)
 Description: Toolkit for listing, checking and fixing eblob blobs.
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [aliases]
 test=pytest
+

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ setup(name='eblob_kit',
       author_email='shaitkir@gmail.com',
       py_modules=['eblob_kit'],
       install_requires=['Click', 'pyhash'],
+      setup_requires=['pytest-runner'],
+      tests_require=['pytest', 'pytest-mock'],
       entry_points='''
           [console_scripts]
           eblob_kit=eblob_kit:main

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ setup(name='eblob_kit',
       author_email='shaitkir@gmail.com',
       py_modules=['eblob_kit'],
       install_requires=['Click', 'pyhash'],
-      setup_requires=['pytest-runner'],
+      setup_requires=[
+        'pytest-runner==2.9',
+        'setuptools_scm<=1.9',
+      ],
       tests_require=['pytest', 'pytest-mock'],
       entry_points='''
           [console_scripts]

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,59 @@
+"""Tests common stuff."""
+import struct
+
+import eblob_kit
+
+
+def generate_key(start=0):
+    """Generate valid key for testing."""
+    return ''.join([chr((start + x) % 256) for x in xrange(eblob_kit.DiskControl.key_size)])
+
+
+def make_header(key='', data_size=0, disk_size=0, flags=eblob_kit.RecordFlags(0), position=0):
+    """Create DiskControl with default values.
+
+    Parameters equals to eblob_kit.DiskControl constructor.
+
+    With all defaults arguments construct an 'empty header', usually such a header should be considered 'non valid',
+    used as a stub for tesing purposes.
+
+    :rtype eblob_kit.DiskControl
+    """
+    return eblob_kit.DiskControl(key=key, data_size=data_size, disk_size=disk_size, flags=flags, position=position)
+
+
+def header_to_bytes(header):
+    """Construct bytes sequence DiskControl header representation.
+
+    :param eblob_kit.DiskControl header: disk control header to pack into created buffer.
+
+    :rtype: str
+    """
+    fmt = '<{}s4Q'.format(eblob_kit.DiskControl.key_size)
+    return struct.pack(fmt, header.key, header.flags.flags, header.data_size, header.disk_size, header.position)
+
+
+def make_blob_byte_squence(sizes=None, fill=0xf1):
+    """Create a data blob.
+
+    :param (List[int] | None) sizes: list of data chunks sizes
+    :param int fill: fill the buffer with provided value.
+
+    :rtype: bytearray
+    """
+    position = 0
+    if sizes is None:
+        sizes = []
+
+    total_sizes = sum(size + eblob_kit.DiskControl.size for size in sizes)
+    buff = bytearray([fill] * total_sizes)
+
+    for key_sequence, size in enumerate(sizes):
+        disk_size = eblob_kit.DiskControl.size + size
+        header = make_header(key=generate_key(key_sequence), disk_size=disk_size, position=position)
+
+        buff[position:position+eblob_kit.DiskControl.size] = header_to_bytes(header)
+
+        position += disk_size
+
+    return buff

--- a/tests/test_blob_repairer.py
+++ b/tests/test_blob_repairer.py
@@ -1,0 +1,446 @@
+"""Test mocks for eblob_kit.BlobRepairer.
+
+TODO(karapuz): implement tests for BlobRepairer methods:
+  - fix
+  - print_check_report
+  - check
+  - recover_index
+  - recover_blob
+  - copy_valid_records
+
+TODO(karapuz): move common patch wrappers to fixture.
+TODO(karapuz): complete tests parameters docs.
+
+"""
+import mock
+import pytest
+
+from eblob_kit import BlobRepairer
+from eblob_kit import EllipticsHeader
+from eblob_kit import RecordFlags
+
+from common import make_header
+
+
+TEST_BLOB_PATH = 'src/path'
+TEST_BLOB_PREFIX = 'test_data-0.0'
+
+TEST_DESTINATION_PATH = 'dst/path'
+
+TEST_INDEX_PATH = TEST_BLOB_PATH + '/' + 'test_data-0.0.index'
+TEST_INDEX_SORTED_PATH = TEST_BLOB_PATH + '/' + 'test_data-0.0.index.sorted'
+
+TEST_DATA_PATH = TEST_BLOB_PATH + '/' + TEST_BLOB_PREFIX
+
+
+@pytest.mark.parametrize('header, data_len, check_result', [
+    (make_header(data_size=1, disk_size=128), 512, True),
+    # Malformed header has empty disk_size.
+    (make_header(data_size=1, position=1), 512, False),
+    # Malformed header has out of range position (position + disk_size > total data len).
+    (make_header(data_size=1, disk_size=128, position=1), 128, False),
+    # Malformed header has empty data_size, but it is committed and not removed.
+    (make_header(disk_size=128), 512, False),
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_check_header_without_flags(_mocked_index,
+                                    mocked_data_file,
+                                    mocked_exist,
+                                    header,
+                                    data_len,
+                                    check_result):
+    """Check generated header whith BlobRepairer.check_header.
+
+    Constructs various headers and check them for validity.
+
+    :param eblob_kit.DiskControl header: header stub.
+
+    """
+    # DataFile mock
+    mocked_data_file.return_value.__len__.return_value = data_len
+
+    # Blob mock
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+
+    assert blob_repairer.check_header(header) == check_result
+
+
+@pytest.mark.parametrize('flags', [
+   RecordFlags.UNCOMMITTED,
+   RecordFlags.REMOVED,
+   RecordFlags.UNCOMMITTED | RecordFlags.EXTHDR,
+   RecordFlags.REMOVED | RecordFlags.EXTHDR,
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_check_header_with_flags_nodata_size(_mocked_exists, mocked_data_file, _mocked_index, flags):
+    """Tested valid headers with different flags combination.
+
+    :param eblob_kit.RecordFlags flags: bit flags to be used with eblob_kit.DiskControl
+
+    """
+    # DataFile mock
+    mocked_data_file.return_value.__len__.return_value = 512
+
+    header = make_header(flags=RecordFlags(flags), disk_size=128)
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.check_header(header)
+
+
+@pytest.mark.parametrize('data_size, disk_size, expect', [
+    (128, 128, False),
+    # 64 below - checksum size
+    (128, 128 + EllipticsHeader.size + 64 - 1, False),
+    (128, 128 + EllipticsHeader.size + 64, True),
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_check_header_with_exthdr_and_datasize(_mocked_exists,
+                                               mocked_data_file,
+                                               _index_file,
+                                               data_size,
+                                               disk_size,
+                                               expect):
+    """Check header with EXTHDR and incorrect data_size.
+
+    Checks for:
+
+      header.data_size + EllipticsHeader.size(48) + checksum_size(64) > header.disk_size
+
+    """
+    header = make_header(data_size=data_size, disk_size=disk_size, flags=RecordFlags(RecordFlags.EXTHDR))
+
+    # Return big enough constant to suppress preliminary checks in BlobRepairer.check_header.
+    mocked_data_file.return_value.__len__.return_value = 512
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.check_header(header) == expect
+
+
+@pytest.mark.parametrize('position, end, header_position, holes, holes_size, check_header_called',
+                         [
+                             (0,   3,   0, 1, 3, 1),
+                             (0,   1, 100, 1, 1, 1),
+                             (1,   3,   1, 1, 2, 1),
+                             (5,   6,   6, 1, 1, 1),
+                             (5,   5,   5, 0, 0, 0),
+                         ])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_check_hole(_mock_exist,
+                    data_mock,
+                    _index_mock,
+                    mocker,
+                    position,
+                    end,
+                    header_position,
+                    holes,
+                    holes_size,
+                    check_header_called):
+    """Check generated DiskControl header with BlobRepairer.check_hole.
+
+    TODO(karapuz): try to move common for all test patch code to BlobRepairer fixture.
+
+    :param int position:
+    :param int end:
+    :param int header_position:
+    :param int holes:
+    :param int holes_size:
+    :param int check_header_called:
+
+    """
+    # DataFile mock
+    dummy_header = make_header(position=header_position)
+    data_mock.return_value.read_disk_control.return_value = dummy_header
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.valid
+
+    mocker.spy(blob_repairer, 'check_header')
+
+    blob_repairer.check_hole(position, end)
+
+    assert blob_repairer.stat.holes == holes
+    assert blob_repairer.stat.holes_size == holes_size
+
+    if check_header_called:
+        blob_repairer.check_header.assert_called_with(dummy_header)
+
+    assert blob_repairer.check_header.call_count == check_header_called
+
+
+@pytest.mark.parametrize('header_index, position, headers', [
+    (1, 8, [make_header(disk_size=5, position=3), make_header()]),
+    (0, 0, [make_header(), make_header()]),
+    (1, 11, [make_header(disk_size=5, position=3), make_header()]),
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_resolve_mispositioned_record_assert(_mocked_exists,
+                                             mocked_data_file,
+                                             _index_file_mock,
+                                             header_index,
+                                             position,
+                                             headers):
+    """Check for resolve_mispositioned_record fail on assert.
+
+    :param int header_index:
+    :param int position:
+    :param List[eblob_kit.DiskControl] headers:
+
+    """
+    mocked_data_file.return_value.read_disk_control.return_value = make_header()
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.valid
+
+    with pytest.raises(AssertionError):
+        blob_repairer._index_headers = headers
+        blob_repairer.resolve_mispositioned_record(header_index, position, [])
+
+
+@pytest.mark.parametrize('header_index, position, headers, expect_result', [
+    (1, 0, [make_header(), make_header(), ], False),
+    (2, 2, [make_header(), make_header(disk_size=1, position=1), make_header(position=2), ], True),
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_resolve_mispositioned_record_with_empty_disk_control(_mocked_exists,
+                                                              mocked_data_file,
+                                                              _mocked_index_file,
+                                                              header_index,
+                                                              position,
+                                                              headers,
+                                                              expect_result):
+    """Check different combinations of headers sequences.
+
+    Check different combinations of headers sequences with
+    BlobRepairer.resolve_mispositioned_record and empty disk control.
+
+    TODO(karapuz): not all branches are tested within:
+      eblob_kit.BlobRepairer.resolve_mispositioned_record
+
+    :param int header_index:
+    :param int position:
+    :param List[eblob_kit.DiskControl] headers:
+    :param bool expect_result:
+
+    """
+    mocked_data_file.return_value.read_disk_control.return_value = make_header()
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.valid
+
+    blob_repairer._index_headers = headers
+
+    assert blob_repairer.resolve_mispositioned_record(header_index, position, []) == expect_result
+
+
+@pytest.mark.parametrize('header_index, position, disk_control_position', [
+    (1, 8, 4),
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_resolve_mispositioned_record_with_positioned_disk_control(_mocked_exists,
+                                                                   mocked_data_file,
+                                                                   _mocked_index_file,
+                                                                   header_index,
+                                                                   position,
+                                                                   disk_control_position):
+    """Check different combinations of headers sequences with non empty disk_control.
+
+    TODO(karapuz): add test to this test case.
+
+    :param int header_index:
+    :param int position:
+    :param int disk_control_position:
+
+    """
+    mocked_data_file.return_value.read_disk_control.return_value = make_header(position=disk_control_position)
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.valid
+
+    blob_repairer._index_headers = [make_header(disk_size=5, position=3), make_header(position=4), ]
+
+    assert not blob_repairer.resolve_mispositioned_record(header_index, position, [])
+
+
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_resolve_mismatch(_mocked_exists, _mocked_data_file, _mocked_index_file):
+    """Check generated headers sequence with BlobRepairer.resolve_mismatch."""
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+    assert blob_repairer.valid
+
+    flags = RecordFlags(0)
+    args_list = [make_header(key='', data_size=x, disk_size=2 * x, flags=flags, position=3 * x)
+                 for x in xrange(3)]
+    blob_repairer.resolve_mismatch(*args_list)
+
+    assert not blob_repairer.valid
+    assert blob_repairer.stat.mismatched_headers == [tuple(args_list)[:2]]
+
+
+@pytest.mark.parametrize('index, is_sorted, valid, malformed_headers', [
+    ([make_header(key='b'), make_header(key='a', disk_size=3)],  # Index
+     False,  # index sorted.
+     False,  # check result valid.
+     1, ),
+    ([make_header(), make_header(key='a', disk_size=128)],  # Index
+     True,  # index sorted.
+     False,  # check result valid.
+     1, ),
+    ([make_header(key='a',
+                  disk_size=128,
+                  data_size=1,
+                  position=1),
+      make_header(key='b',
+                  disk_size=128,
+                  data_size=1,
+                  position=2)],
+     False,  # index sorted.
+     True,  # check result valid.
+     0, )
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_check_index_valid_size_no_order_error(_mocked_exists,
+                                               mocked_data_file,
+                                               mocked_index_file,
+                                               mocker,
+                                               index,
+                                               is_sorted,
+                                               valid,
+                                               malformed_headers):
+    """Check generated headers sequence with eblob_kit.BlobRepairer.check_index.
+
+    :param List[eblob_kit.DiskControl] index:
+    :param bool is_sorted:
+    :param bool valid:
+    :param int malformed_headers:
+
+    """
+    mocked_index_file.return_value.__iter__.return_value = iter(index)
+
+    type(mocked_index_file.return_value).sorted = mocker.PropertyMock(return_value=is_sorted)
+
+    # Need to set some abstract value in order to make inner
+    # check_header return True.
+    mocked_data_file.return_value.__len__.return_value = 256
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+
+    assert blob_repairer.valid
+    assert not blob_repairer.stat.index_order_error
+
+    blob_repairer.check_index(True)
+
+    assert blob_repairer.valid == valid
+
+    assert not blob_repairer.stat.invalid_index_size
+    assert not blob_repairer.stat.index_order_error
+
+    assert blob_repairer.stat.index_malformed_headers == malformed_headers
+
+
+@pytest.mark.parametrize('index, sorted, invalid_index_size, index_order_error', [
+    (EOFError(), False, True, False),
+    ([make_header(key='b', disk_size=128, data_size=1, position=1),
+      make_header(key='a', disk_size=128, data_size=1, position=2)],
+     True,  False,  True)
+])
+@mock.patch('eblob_kit.IndexFile', autospec=True)
+@mock.patch('eblob_kit.DataFile', autospec=True)
+@mock.patch('os.path.exists', return_value=True)
+def test_check_index_non_valid(_mocked_exists,
+                               mocked_data_file,
+                               mocked_index_file,
+                               mocker,
+                               index,
+                               sorted,
+                               invalid_index_size,
+                               index_order_error):
+    """Check generated headers sequence with eblob_kit.BlobRepairer.check_index.
+
+    TODO(karapuz): add test cases.
+
+    :param List[eblob_kit.DiskControl] index:
+    :param bool sorted:
+    :param bool invalid_index_size:
+    :param bool index_order_error:
+
+    """
+    if isinstance(index, Exception):
+        mocked_index_file.return_value.__iter__.side_effect = index
+    else:
+        mocked_index_file.return_value.__iter__.return_value = iter(index)
+
+    type(mocked_index_file.return_value).sorted = mocker.PropertyMock(return_value=sorted)
+
+    # Need to set some abstract value in order to make inner
+    # check_header return True.
+    mocked_data_file.return_value.__len__.return_value = 256
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+
+    assert blob_repairer.valid
+    assert not blob_repairer.stat.index_order_error
+
+    blob_repairer.check_index(True)
+
+    assert not blob_repairer.valid
+    assert blob_repairer.stat.invalid_index_size == invalid_index_size
+
+    assert blob_repairer.stat.index_order_error == index_order_error
+
+    assert blob_repairer.stat.index_malformed_headers == 0
+
+
+def test_fix(mocker):
+    """Tests for BlobRepairer.fix.
+
+    TODO(karapuz): function test for 'fix' command, following test not completed.
+
+    """
+    # IndexFile mock
+    index_file_class = mocker.patch('eblob_kit.IndexFile', autospec=True)
+
+    index_header = make_header(key='', data_size=1, disk_size=2, position=3, flags=4)
+    index_file_class.return_value.__iter__.return_value = iter([index_header])
+
+    # DataFile mock
+    data_file_class = mocker.patch('eblob_kit.DataFile', autospec=True)
+
+    # Blob mock
+    mocker.patch('eblob_kit.Blob.create', )
+
+    mocker.patch('os.path.exists', return_value=True)
+
+    blob_repairer = BlobRepairer(TEST_BLOB_PATH)
+
+    mocker.spy(blob_repairer, 'check')
+    mocker.spy(blob_repairer, 'check_index')
+    mocker.spy(blob_repairer, 'print_check_report')
+
+    blob_repairer.fix(TEST_DESTINATION_PATH, noprompt=True)
+
+    # Check the self.check method
+    assert blob_repairer.check.call_count == 1
+    blob_repairer.check.assert_called_with(True, False)
+
+    assert blob_repairer.check_index.call_count == 1
+    blob_repairer.check_index.assert_called_with(False)
+
+    assert blob_repairer.print_check_report.call_count == 1

--- a/tests/test_data_file.py
+++ b/tests/test_data_file.py
@@ -1,0 +1,100 @@
+"""DataFile tests."""
+import pytest
+
+import sys
+
+# Used for file access emulation.
+import StringIO
+
+import common
+import eblob_kit
+
+
+TEST_OFFSETS_RANGE = 7
+
+
+if sys.version_info < (3, 0):
+    OPEN_TO_PATCH = '__builtin__.open'
+else:
+    OPEN_TO_PATCH = 'builtins.open'
+
+
+def _make_buffer_with_valid_diskcontrol(buffer_size, disk_control_offset, disk_control):
+    b = bytearray(buffer_size)
+    b[disk_control_offset: disk_control_offset + eblob_kit.DiskControl.size] = common.header_to_bytes(disk_control)
+
+    return b
+
+
+@pytest.fixture(params=[
+    (1, 0, 0, 0, 0),
+    (1, 0x01, 3, 4, 5),
+    (3, 0xFFFF, 2**32, 2 ** 32, 2 ** 32),
+])
+def disk_control(request):
+    """Generate some valid DiskControl instance.
+
+    TODO(karapuz): add parameters with some marginal values.
+    TODO(karapuz): use named tuple for test cases.
+
+    """
+    return eblob_kit.DiskControl(key=common.generate_key(request.param[0]),
+                                 flags=eblob_kit.RecordFlags(request.param[1]),
+                                 data_size=request.param[2],
+                                 disk_size=request.param[3],
+                                 position=request.param[4])
+
+
+@pytest.mark.parametrize('disk_control_offset', xrange(TEST_OFFSETS_RANGE))
+def test_read_disk_control_valid(mocker, disk_control, disk_control_offset):
+    """Test read_disk_control along with eblob_kit.DataFile.read method."""
+    dummy_buffer = _make_buffer_with_valid_diskcontrol(eblob_kit.DiskControl.size * 2,
+                                                       disk_control_offset,
+                                                       disk_control)
+
+    with mocker.patch(OPEN_TO_PATCH, return_value=StringIO.StringIO(dummy_buffer)),\
+            mocker.patch('eblob_kit.DataFile.__len__', return_value=len(dummy_buffer)):
+
+        data_file = eblob_kit.DataFile('some/path')
+        dummy_disk_control = data_file.read_disk_control(disk_control_offset)
+
+        assert dummy_disk_control == disk_control
+
+
+@pytest.mark.xfail(raises=EOFError)
+@pytest.mark.parametrize('disk_control_offset', xrange(TEST_OFFSETS_RANGE))
+def test_read_disk_control_with_exception(mocker, disk_control, disk_control_offset):
+    """Test read_disk_control exceptions."""
+    dummy_buffer = _make_buffer_with_valid_diskcontrol(eblob_kit.DiskControl.size - 1,
+                                                       disk_control_offset,
+                                                       disk_control)
+
+    with mocker.patch(OPEN_TO_PATCH, return_value=StringIO.StringIO(dummy_buffer)),\
+            mocker.patch('eblob_kit.DataFile.__len__', return_value=len(dummy_buffer)):
+        eblob_kit.DataFile('some/path').read_disk_control(disk_control_offset)
+
+
+@pytest.mark.parametrize('sizes', [
+    [1, 2, 3],
+    [1],
+    [],
+    [0],
+    [0, 1],
+    [0, 1, 1024, 512, 3]
+])
+def test_data_file_iter(mocker, sizes):
+    """Check iterator over eblob_kit.DataFile records."""
+    dummy_buffer = common.make_blob_byte_squence(sizes)
+
+    with mocker.patch(OPEN_TO_PATCH, return_value=StringIO.StringIO(dummy_buffer)),\
+            mocker.patch('eblob_kit.DataFile.__len__', return_value=len(dummy_buffer)):
+
+        data_file = eblob_kit.DataFile('some/path')
+        cnt = 0
+        total_size = 0
+        for disk_control in data_file:
+            total_size += disk_control.disk_size
+            cnt += 1
+
+        assert cnt == len(sizes)
+        assert len(dummy_buffer) == total_size

--- a/tests/test_disk_control.py
+++ b/tests/test_disk_control.py
@@ -1,0 +1,35 @@
+"""Test DiskControl structure."""
+import pytest
+
+from common import generate_key
+from common import header_to_bytes
+
+from eblob_kit import DiskControl
+from eblob_kit import RecordFlags
+
+
+@pytest.mark.parametrize('header', [
+    DiskControl(key=generate_key(1),
+                data_size=1,
+                disk_size=2,
+                flags=RecordFlags(0),
+                position=0),
+    DiskControl(key=generate_key(2),
+                data_size=3,
+                disk_size=4,
+                flags=RecordFlags(RecordFlags.CORRUPTED),
+                position=1),
+    DiskControl(key=generate_key(3),
+                data_size=4,
+                disk_size=5,
+                flags=RecordFlags(RecordFlags.EXTHDR),
+                position=2),
+    DiskControl(key=generate_key(4),
+                data_size=5,
+                disk_size=6,
+                flags=RecordFlags(RecordFlags.CORRUPTED | RecordFlags.CHUNKED_CSUM),
+                position=3),
+])
+def test_diskcontrol_from_bytes(header):
+    """Dump header to byte sequence and construct it back."""
+    assert header == DiskControl.from_raw(header_to_bytes(header))

--- a/tests/test_get_checksum_size.py
+++ b/tests/test_get_checksum_size.py
@@ -1,0 +1,45 @@
+"""Tests for eblob_kit.get_checksum_size."""
+import pytest
+
+from common import make_header
+
+from eblob_kit import get_checksum_size
+from eblob_kit import RecordFlags
+
+
+# Marginal cases of header.data_size parameters.
+marginal_data_sizes = [0, 1, 2, 3, 1 << 20, 1 << 20 + 1, (1 << 20) * 2 + 1]
+
+
+@pytest.mark.parametrize('data_size, checksum_size', [
+    # TODO(karapuz): is data_size == 0 valid?
+    (0, 8),
+    (1, 16),
+    (1, 16),
+    (2, 16),
+    (3, 16),
+    (1 << 20, 16),
+    (1 << 20 + 1, 24),
+    ((1 << 20) * 2 + 1, 32),
+])
+def test_get_checksum_size_for_chunked_csum(data_size, checksum_size):
+    """Count checksum for headers with CHUNKED_CSUM flag."""
+    header = make_header(data_size=data_size, flags=RecordFlags(RecordFlags.CHUNKED_CSUM))
+    assert get_checksum_size(header) == checksum_size
+
+
+@pytest.mark.parametrize('data_size', marginal_data_sizes)
+def test_get_checksum_size_for_nocsum(data_size):
+    """Count checksum for headers with CHUNKED_CSUM flag.
+
+    No metter what is data_size of header, checksum size should be zero.
+    """
+    header = make_header(data_size=data_size, flags=RecordFlags(RecordFlags.NOCSUM))
+    assert get_checksum_size(header) == 0
+
+
+@pytest.mark.parametrize('data_size', marginal_data_sizes)
+def test_get_checksum_size_noflags(data_size):
+    """Count checksum for headers with no influencing flags set."""
+    header = make_header(data_size=data_size, flags=RecordFlags(0))
+    assert get_checksum_size(header) == 64


### PR DESCRIPTION
 - by default _fix_ command outputs pure json to _stdout_.
 - with `-v` option, processing information reported  to _stdout_,  `-v` option could be counted to increase verbosity, e.g: `-vv` adds extra output to logger. 

**TODO**:
 - [x] tests