### PR TITLE
Forbid destination files overwrite by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+eblob-kit (0.1.2) unstable; urgency=medium
+
+  * refact: creation mode can be set for Blob,IndexFile
+  * feat: mark blob index as sorted on creation
+  * feat: prohibit distination files overwrite by default
+  * refact: join two if branches with same condition
+  * test: make tests passable with recent updates
+  * test: check for destination writability
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Wed, 06 Feb 2019 14:31:05 +0300
+
 eblob-kit (0.1.1) unstable; urgency=low
 
   * feat: make path for resulting artifact file

--- a/eblob_kit.py
+++ b/eblob_kit.py
@@ -407,10 +407,10 @@ class IndexFile(object):
         self._file = open(path, mode)
 
     @staticmethod
-    def create(path):
+    def create(path, mode='ab'):
         """Create IndexFile for @path."""
-        open(path, 'ab').close()
-        return IndexFile(path, mode='ab')
+        open(path, mode).close()
+        return IndexFile(path, mode=mode)
 
     @property
     def path(self):
@@ -524,11 +524,12 @@ class Blob(object):
         self._data_file = DataFile(path, mode)
 
     @staticmethod
-    def create(path):
+    def create(path, mark_index_sorted=False, mode='ab'):
         """Create new Blob at @path."""
-        open(path + '.index', 'ab').close()
-        open(path, 'ab').close()
-        return Blob(path, 'ab')
+        index_suffix = '.index.sorted' if mark_index_sorted else '.index'
+        open(path + index_suffix, mode).close()
+        open(path, mode).close()
+        return Blob(path, mode)
 
     @property
     def index(self):

--- a/eblob_kit.py
+++ b/eblob_kit.py
@@ -64,8 +64,6 @@ def dump_to_file(file_name, results):
 def is_destination_writable(src_path, dst_path, overwrite=False):
     """Check if 'dst_path' file writable.
 
-    TODO(karapuz): tests.
-
     NOTE: always prohibit writing from src_path to dst_path if it is same file.
 
     """
@@ -1098,9 +1096,8 @@ class BlobRepairer(object):
 
         for header in self._blob.data:
             if not header:
-                logging.error('I have faced with broken record which I can not skip.')
-            if not header:
                 skipped_records += 1
+                logging.error('I have faced with broken record which I have to skip.')
             elif header.flags.removed:
                 removed_records += 1
             else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='eblob_kit',
-      version='0.1.0',
+      version='0.1.2',
       author='Kirill Smorodinnikov',
       author_email='shaitkir@gmail.com',
       py_modules=['eblob_kit'],

--- a/tests/test_blob_repairer.py
+++ b/tests/test_blob_repairer.py
@@ -420,11 +420,15 @@ def test_fix(mocker):
     index_header = make_header(key='', data_size=1, disk_size=2, position=3, flags=4)
     index_file_class.return_value.__iter__.return_value = iter([index_header])
 
+    # TODO(karapuz): add test for sorted case
+    type(index_file_class.return_value).sorted = mocker.PropertyMock(return_value=False)
+
     # DataFile mock
     data_file_class = mocker.patch('eblob_kit.DataFile', autospec=True)
 
     # Blob mock
     mocker.patch('eblob_kit.Blob.create', )
+    mocker.patch('eblob_kit.is_destination_writable', return_value=True)
 
     mocker.patch('os.path.exists', return_value=True)
 

--- a/tests/test_writable_path.py
+++ b/tests/test_writable_path.py
@@ -1,0 +1,23 @@
+"""Check eblob_kit.is_destination_writable."""
+import pytest
+
+from eblob_kit import is_destination_writable
+
+
+@pytest.mark.parametrize('src_path, dst_path, dst_exist, overwrite, expect', [
+    ('/a/b', '/c/d', False, False, True),
+    ('/a/b', '/c/d', False, True, True),
+    ('/a/b', '/c/d', True, False, False),
+    ('/a/b', '/c/d', True, True, True),
+
+    ('/a/b', '/a/b', False, False, False),
+    ('/a/b', '/a/b', False, True, False),
+    ('/a/b', '/a/b', True, False, False),
+    ('/a/b', '/a/b', True, True, False),
+])
+def test_is_destination_writable(mocker, src_path, dst_path, dst_exist, overwrite, expect):
+    """Test for writability check."""
+    mocker.patch('os.path.exists', return_value=(src_path == dst_path) or dst_exist)
+    mocker.patch('os.path.samefile', return_value=(src_path == dst_path))
+
+    assert is_destination_writable(src_path, dst_path, overwrite) == expect


### PR DESCRIPTION
 - forbid recovery overwrite of destination paths.
 - exceptions of BlobRepairer.fix command are stored in Json artifact.
 - minor refactorings.
