### PR TITLE
Switch debian buildsystem to pybuild

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+eblob-kit (0.1.4) unstable; urgency=medium
+
+  * fix: make tests work with modern pytest version
+  * chore: switch debian buildsystem to pybuild
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Thu, 21 Feb 2019 12:53:37 +0300
+
 eblob-kit (0.1.3) unstable; urgency=medium
 
   * fix: rethrow fix_blob_command exception

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,12 @@ Priority: optional
 Build-Depends: python-setuptools (>= 0.6b3),
                python-all (>= 2.6.6-3),
                debhelper (>= 7.4.3),
+               dh-python,
                python-click (>= 5.1),
-               python-certifi
+               python-certifi,
+               python-pyhash,
+               python-mock,
+               python-tox
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 
@@ -14,5 +18,6 @@ Package: eblob-kit
 Architecture: all
 Depends: ${misc:Depends},
          ${python:Depends},
-         python-click (>= 5.1)
+         python-click (>= 5.1),
+         python-pyhash
 Description: Toolkit for listing, checking and fixing eblob blobs.

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,21 @@
 #!/usr/bin/make -f
 
+#
+# Nasty hack to allow installation of tox deps packages to
+# virtualenv: {home_dir}/.pydistutils.cfg  created if not exists on any
+# pybuild invocation (--clean/build/test) and contains `install-path`
+# set to system folders which in turn are write protected, so
+# easy_install fails to update setuptools, pip, etc on tox startup.
+#
+# If file is removed, it is recreated on next pybuild step invocation.
+#
+# It seems that virtualenv shipped with trusty is affected (other dists
+# are not checked).
+#
+export PYBUILD_BEFORE_TEST=truncate -s0 {home_dir}/.pydistutils.cfg
+export PYBUILD_AFTER_TEST=rm {home_dir}/.pydistutils.cfg
+
+export PYBUILD_TEST_TOX=1
+
 %:
-	dh $@ --with python2 --buildsystem=python_distutils
-
-
+	dh $@ --with python2 --buildsystem=pybuild

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[aliases]
-test=pytest
-

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class PyTest(TestCommand):
 
 
 setup(name='eblob_kit',
-      version='0.1.2',
+      version='0.1.4',
       author='Kirill Smorodinnikov',
       author_email='shaitkir@gmail.com',
       py_modules=['eblob_kit'],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,24 @@
 # -*- coding: utf-8 -*-
 
+import sys
+
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+
+class PyTest(TestCommand):
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
 
 setup(name='eblob_kit',
       version='0.1.2',
@@ -8,11 +26,11 @@ setup(name='eblob_kit',
       author_email='shaitkir@gmail.com',
       py_modules=['eblob_kit'],
       install_requires=['Click', 'pyhash'],
-      setup_requires=[
-        'pytest-runner==2.9',
-        'setuptools_scm<=1.9',
-      ],
       tests_require=['pytest', 'pytest-mock'],
+      test_suite='tests',
+      cmdclass={
+        "test": PyTest,
+      },
       entry_points='''
           [console_scripts]
           eblob_kit=eblob_kit:main

--- a/tests/test_blob_repairer.py
+++ b/tests/test_blob_repairer.py
@@ -500,9 +500,9 @@ def test_fix(mocker):
 
     # Check the self.check method
     assert blob_repairer.check.call_count == 1
-    blob_repairer.check.assert_called_with(True, False)
+    blob_repairer.check.assert_called_with(verify_csum=True, fast=False)
 
     assert blob_repairer.check_index.call_count == 1
-    blob_repairer.check_index.assert_called_with(False)
+    blob_repairer.check_index.assert_called_with(fast=False)
 
     assert blob_repairer.print_check_report.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist =
+    py27
+
+[testenv:py27]
+sitepackages = true
+# pybuild sets http(s)_proxy environments vars
+# to localhost:9 in order to protect from pip
+# downloadings. Remove protection temporary for
+# tox based tests.
+setenv =
+    http_proxy =
+    https_proxy =
+deps =
+    pyhash
+    click>=5.1
+    pytest
+    pytest-mock
+    mock
+commands =
+    pytest -ra -vl --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
Tests would be run on Debian package build. Not sure that this is the best way to accomplish this, it seems that it should be part of CI procedure, but it occasionally works with tox, pybuild and some tricks.

Note that if tests will fails, Debian build will also fail.